### PR TITLE
Fix post-increment arithmetic causing early exit under set -e

### DIFF
--- a/scripts/bk-install-scripts
+++ b/scripts/bk-install-scripts
@@ -76,7 +76,7 @@ for script in "$SCRIPT_DIR"/bk*; do
     ln -s "$script" "$link_path"
     echo -e "${GREEN}✓${NC} $script_name -> $script"
     installed_links+=("$script_name")
-    ((installed_count++))
+    ((++installed_count))
 done
 shopt -u nullglob
 

--- a/scripts/bk-install-skills
+++ b/scripts/bk-install-skills
@@ -66,7 +66,7 @@ for link in "$TARGET_DIR"/*; do
             # Broken symlink - target doesn't exist
             rm "$link"
             cleaned_links+=("$link_name (broken)")
-            ((cleanup_count++))
+            ((++cleanup_count))
         elif [[ "$link_target" == "$SKILLS_DIR"* ]] || [[ "$link_target" == *"/claude-skills/skills/"* ]]; then
             # Symlink points to our skills directory - check if source skill still exists
             source_skill_name=$(basename "$link_target")
@@ -74,7 +74,7 @@ for link in "$TARGET_DIR"/*; do
                 # Source skill no longer exists (renamed or removed)
                 rm "$link"
                 cleaned_links+=("$link_name (stale - source removed)")
-                ((cleanup_count++))
+                ((++cleanup_count))
             fi
         fi
     fi

--- a/scripts/bk-install-skills-codex
+++ b/scripts/bk-install-skills-codex
@@ -66,7 +66,7 @@ for skill_dir in "$SKILLS_DIR"/*; do
         ln -s "$skill_dir" "$target_link"
         echo -e "${GREEN}✓${NC} $skill_name -> $skill_dir"
         installed_skills+=("$skill_name")
-        ((installed_count++))
+        ((++installed_count))
     fi
 
 done
@@ -100,7 +100,7 @@ for link in "$TARGET_DIR"/*; do
     if [ -L "$link" ] && [ ! -e "$link" ]; then
         link_name=$(basename "$link")
         broken_links+=("$link_name")
-        ((broken_count++))
+        ((++broken_count))
     fi
 
 done


### PR DESCRIPTION
## Summary

- **Bug:** `((count++))` (post-increment) evaluates to `0` on the first increment when the counter starts at `0`, which returns exit code `1` in bash. Combined with `set -e`, this causes install scripts to exit after processing only the first item.
- **Fix:** Changed to `((++count))` (pre-increment) which evaluates to `1`, returning exit code `0`. This matches the pattern already used correctly in `bk-install-skills` line 119.
- **Affected files:** `bk-install-scripts`, `bk-install-skills`, `bk-install-skills-codex` (5 occurrences total)

## Test plan

- [ ] Run `bk-install-scripts` with `set -e` and verify all `bk*` scripts are symlinked (not just the first one)
- [ ] Run `bk-install-skills-codex` and verify all skills are symlinked
- [ ] Run `bk-install-skills` with stale symlinks present to verify cleanup_count works

🤖 Generated with [Claude Code](https://claude.com/claude-code)